### PR TITLE
fixing the license display cc0 licensing instead of MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Certificate Infrastructure
 
-[![License](https://img.shields.io/badge/license-MIT-blue?style=for-the-badge)](https://choosealicense.com/licenses/mit/)
+[![License](https://img.shields.io/badge/License-CC0_1.0-blue?style=for-the-badge)](https://choosealicense.com/licenses/cc0-1.0/)
 ![commit history](https://img.shields.io/github/last-commit/cdcgov/ocio-certificates?label=commits&style=for-the-badge)
 
 > [!TIP]


### PR DESCRIPTION
## Updates

- Doc only update, corrected the license link to CC0 instead of MIT.

## Testing Steps

- None, documentation only update.

## Notes

-
